### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ZE07CO
-version=1.0 Dev
+version=1.0-Dev
 author=Emre TEMELKURAN
 maintainer=Emre TEMELKURAN
 sentence=This library makes possible to communicate your Arduino with ZE07CO CO Sensor Module by Winsen.


### PR DESCRIPTION
The previous `version` value caused the Arduino IDE to display warnings:
```
Invalid version found: 1.0 Dev
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format